### PR TITLE
changed const to var to support old browsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .DS_Store
+/.idea

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const createTypes = require('./src/createTypes');
-const composeReducer = require('./src/composeReducer');
+var createTypes = require('./src/createTypes');
+var composeReducer = require('./src/composeReducer');
 
 module.exports = {
   composeReducer: composeReducer,

--- a/src/composeReducer.js
+++ b/src/composeReducer.js
@@ -3,16 +3,16 @@ function defaultFallback(state) {
 }
 
 function composeReducer(namespace, mapping, initialState, fallback) {
-  const namespacedMapping = {};
+  var namespacedMapping = {};
 
   Object.keys(mapping).map(function(key) {
-    const newkey = [namespace, key].join('/');
+    var newkey = [namespace, key].join('/');
     namespacedMapping[newkey] = mapping[key];
   });
 
   return function(state, action) {
-    const handler = namespacedMapping[action.type];
-    
+    var handler = namespacedMapping[action.type];
+
     return (
       handler 
         ? handler(state || initialState, action) 


### PR DESCRIPTION
There is an error in old browsers
`SyntaxError: Unexpected keyword 'const'. Const declarations are not supported in strict mode.`
