### PR TITLE
Added ability to specify object as reducer

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -3,4 +3,5 @@ const modules = BABEL_ENV === 'cjs' || NODE_ENV === 'test' ? 'commonjs' : false
 
 module.exports = {
   presets: [['@babel/preset-env', { loose: true, modules }]],
+  plugins: ['@babel/plugin-transform-object-assign']
 }

--- a/README.md
+++ b/README.md
@@ -42,10 +42,9 @@ const openSideBar = state => ({
   open: true,
 })
 
-const closeSideBar = state => ({
-  ...state,
-  open: false,
-})
+// if your reducer doesn't require state and action
+// you can declare it as object that describes changes
+const closeSideBar = { open: false }
 
 export default composeReducer({
   types: TYPES,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-compose-reducer",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Reducer's composer for Redux",
   "main": "lib/index.js",
   "unpkg": "dist/index.js",
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",
+    "@babel/plugin-transform-object-assign": "^7.2.0",
     "@babel/preset-env": "^7.1.0",
     "babel-core": "^7.0.0-bridge",
     "babel-jest": "^23.6.0",

--- a/src/composeReducer.js
+++ b/src/composeReducer.js
@@ -1,4 +1,9 @@
-import { namespacedActionType, isObject, createCapturedError } from './utils'
+import {
+  namespacedActionType,
+  isObject,
+  isFunction,
+  createCapturedError,
+} from './utils'
 
 const composeReducer = (...args) => {
   const {
@@ -15,7 +20,7 @@ const composeReducer = (...args) => {
       (typeof namespace !== 'string' || namespace.length === 0)) ||
     !isObject(initialState) ||
     !isObject(reducers) ||
-    (globalReducer !== undefined && typeof globalReducer !== 'function')
+    (globalReducer !== undefined && !isFunction(globalReducer))
   )
     throw createError(ARGUMENT_ERROR)
 
@@ -49,7 +54,7 @@ const createMapFromTypes = (types, reducers) => {
   const result = {}
   Object.keys(reducers).forEach(key => {
     if (!(key in types)) throw createError(`There is no '${key}' action type.`)
-    result[types[key]] = reducers[key]
+    result[types[key]] = normalizeReducer(reducers[key])
   })
   return result
 }
@@ -57,10 +62,15 @@ const createMapFromTypes = (types, reducers) => {
 const createMapFromNamespace = (namespace, reducers) => {
   const result = {}
   Object.keys(reducers).forEach(type => {
-    result[namespacedActionType(namespace, type)] = reducers[type]
+    result[namespacedActionType(namespace, type)] = normalizeReducer(
+      reducers[type]
+    )
   })
   return result
 }
+
+const normalizeReducer = reducer =>
+  isFunction(reducer) ? reducer : state => Object.assign({}, state, reducer)
 
 export const ARGUMENT_ERROR = `As argument expected object of shape : {
   namespace: 'non empty string',

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,6 +5,8 @@ export const namespacedActionType = (namespace, type) =>
 
 export const isObject = o => o instanceof Object && !Array.isArray(o)
 
+export const isFunction = o => typeof o === 'function'
+
 export const createCapturedError = (message, cst) => {
   const error = new Error(message)
   if (cst && Error.captureStackTrace) Error.captureStackTrace(error, cst)

--- a/test/composeReducer.test.js
+++ b/test/composeReducer.test.js
@@ -80,6 +80,31 @@ describe('composeReducer', () => {
     })
   })
 
+  describe('`reducers` shortcuts', () => {
+    it('produces correct state depends on action type', () => {
+      const reducer = composeReducer({
+        namespace: 'test',
+        initialState: { action: false, action2: false },
+        reducers: {
+          action: { action: true },
+          action2: { action2: true },
+        },
+      })
+
+      let actual = reducer(undefined, { type: 'test/action' })
+      expect(actual).toEqual({
+        action: true,
+        action2: false,
+      })
+
+      actual = reducer(undefined, { type: 'test/action2' })
+      expect(actual).toEqual({
+        action: false,
+        action2: true,
+      })
+    })
+  })
+
   describe('`globalReducer` attribute', () => {
     it('allows to reduce global actions', () => {
       const GLOBAL_ACTION_TYPE = 'GLOBAL/ACTION'


### PR DESCRIPTION
Added ability to declare reducer as an object that describes updates (if you don't need `state` and `action` parameters).

#### Before
```js
const closeSideBar = state => ({
  ...state,
  open: false,
})
```

#### After
```js
const closeSideBar = { open: false }
```