### PR TITLE
Added state shape check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-compose-reducer",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Reducer's composer for Redux",
   "main": "lib/index.js",
   "unpkg": "dist/index.js",

--- a/src/composeReducer.js
+++ b/src/composeReducer.js
@@ -1,8 +1,10 @@
 import {
+  isDev,
   namespacedActionType,
   isObject,
   isFunction,
   createCapturedError,
+  checkStateShape,
 } from './utils'
 
 const composeReducer = (...args) => {
@@ -29,10 +31,11 @@ const composeReducer = (...args) => {
     : createMapFromNamespace(namespace, reducers)
 
   return (state = initialState, action) => {
-    state = typeToReducerMap[action.type]
-      ? typeToReducerMap[action.type](state, action)
-      : state
-    return globalReducer ? globalReducer(state, action) : state
+    const reduce = typeToReducerMap[action.type]
+    if (reduce) state = reduce(state, action)
+    if (globalReducer) state = globalReducer(state, action)
+    if (isDev) checkStateShape(state, initialState, action)
+    return state
   }
 }
 


### PR DESCRIPTION
Added console warning in development mode if reduced `state` contains keys that don't exist in `initialState`. It allows to control `state` shape to prevent unexpected situations.

<img width="608" alt="screen shot 2018-12-18 at 00 11 30" src="https://user-images.githubusercontent.com/950216/50115950-f2c74000-0259-11e9-80fd-6273ad7b0c5c.png">
